### PR TITLE
Add native LM Studio streaming mode and session trace UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 - `src/lmstudio-client.js` - LM Studio API client
 - `src/mcp-client.js` - MCP HTTP client (streamable-http)
 - `src/local-shell-tool.js` - extension-host local shell tool execution
+- `src/local-shell-mirror.js` - dedicated terminal mirror for local shell tool calls
 - `src/chat-runner.js` - LM Studio + local shell + optional MCP tool-call loop
 - `scripts/smoke-test.sh` - endpoint smoke test (outside VS Code)
 
@@ -53,6 +54,7 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 - Trace pane shows execution events, not hidden model chain-of-thought tokens.
 - In native stream mode, trace includes raw stream event names and payload snippets.
 - Output channel logs tool calls with argument payloads (redacted/truncated for sensitive/large values).
+- Local shell execution is mirrored to a `JoshGPT Local Shell` terminal by default.
 
 ## Package Test
 
@@ -66,7 +68,7 @@ Install into an isolated extensions directory:
 
 ```bash
 code --extensions-dir /tmp/vscode-lmstudio-ext-test \
-  --install-extension ./joshgpt-0.0.8.vsix --force
+  --install-extension ./joshgpt-0.0.9.vsix --force
 ```
 
 Verify:
@@ -101,12 +103,16 @@ code --extensions-dir /tmp/vscode-lmstudio-ext-test --list-extensions | grep jos
 - `joshgpt.localShell.maxTimeoutSeconds`
 - `joshgpt.localShell.defaultMaxOutputChars`
 - `joshgpt.localShell.maxOutputChars`
+- `joshgpt.localShell.mirrorTerminalEnabled`
+- `joshgpt.localShell.mirrorTerminalName`
+- `joshgpt.localShell.mirrorTerminalReveal`
 
 ## Tool Calling (OpenAI-Compatible Mode)
 
 - JoshGPT always exposes `run_local_shell_command` when `joshgpt.localShell.enabled=true`.
   - Commands run in the extension host environment.
   - If VS Code is attached to a container, the command runs in that container.
+  - Mirror mode writes command/output/exit status to a dedicated terminal (`joshgpt.localShell.mirrorTerminal*` settings).
 - When `joshgpt.mcp.enabled=true`, JoshGPT also loads MCP tool metadata via `tools/list`.
 - MCP execution tools (`run_host_command`, `run_container_command`) are intentionally excluded from model exposure in JoshGPT.
 - Non-exec MCP tools are still available and executed through MCP `tools/call`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JoshGPT VS Code Extension Template (Spike)
 
 This starter provides a minimal `JoshGPT` VS Code extension that supports:
-- OpenAI-compatible LM Studio REST API for chat and MCP tool-calling.
+- OpenAI-compatible LM Studio REST API for chat, with local shell tool-calling in the extension host.
 - Native LM Studio streaming REST API for rich trace events (including `reasoning.*` when emitted by the model).
 
 ## What It Does
@@ -12,6 +12,7 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 - Adds command `JoshGPT: Ask Model`
 - Adds command `JoshGPT: New Session`
 - Adds command `JoshGPT: MCP Status`
+- Provides built-in local shell tool: `run_local_shell_command`
 - Supports endpoint modes:
   - `openai-compat` (default)
   - `lmstudio-native-stream`
@@ -27,7 +28,8 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 - `src/session-view-provider.js` - webview session UI
 - `src/lmstudio-client.js` - LM Studio API client
 - `src/mcp-client.js` - MCP HTTP client (streamable-http)
-- `src/chat-runner.js` - LM Studio + MCP tool-call loop
+- `src/local-shell-tool.js` - extension-host local shell tool execution
+- `src/chat-runner.js` - LM Studio + local shell + optional MCP tool-call loop
 - `scripts/smoke-test.sh` - endpoint smoke test (outside VS Code)
 
 ## Quick Start
@@ -63,7 +65,7 @@ Install into an isolated extensions directory:
 
 ```bash
 code --extensions-dir /tmp/vscode-lmstudio-ext-test \
-  --install-extension ./joshgpt-0.0.6.vsix --force
+  --install-extension ./joshgpt-0.0.7.vsix --force
 ```
 
 Verify:
@@ -93,12 +95,20 @@ code --extensions-dir /tmp/vscode-lmstudio-ext-test --list-extensions | grep jos
   - Recommended local default: `http://127.0.0.1:8790/mcp`
 - `joshgpt.mcp.timeoutMs`
 - `joshgpt.mcp.maxToolRounds`
+- `joshgpt.localShell.enabled`
+- `joshgpt.localShell.defaultTimeoutSeconds`
+- `joshgpt.localShell.maxTimeoutSeconds`
+- `joshgpt.localShell.defaultMaxOutputChars`
+- `joshgpt.localShell.maxOutputChars`
 
-## MCP Tool Calling (OpenAI-Compatible Mode)
+## Tool Calling (OpenAI-Compatible Mode)
 
-- When `joshgpt.mcp.enabled=true`, JoshGPT requests MCP tool metadata via `tools/list`.
-- Tool schemas are passed to LM Studio in `chat/completions` as OpenAI function tools.
-- If the model returns tool calls, JoshGPT executes them through MCP `tools/call` and feeds results back into the model loop.
+- JoshGPT always exposes `run_local_shell_command` when `joshgpt.localShell.enabled=true`.
+  - Commands run in the extension host environment.
+  - If VS Code is attached to a container, the command runs in that container.
+- When `joshgpt.mcp.enabled=true`, JoshGPT also loads MCP tool metadata via `tools/list`.
+- MCP execution tools (`run_host_command`, `run_container_command`) are intentionally excluded from model exposure in JoshGPT.
+- Non-exec MCP tools are still available and executed through MCP `tools/call`.
 - The loop stops when the model returns a normal assistant response or `joshgpt.mcp.maxToolRounds` is reached.
 
 ## Native Streaming Mode
@@ -107,7 +117,7 @@ code --extensions-dir /tmp/vscode-lmstudio-ext-test --list-extensions | grep jos
 - JoshGPT calls `POST /api/v1/chat` with `stream: true` at `joshgpt.nativeBaseUrl`.
 - Trace pane records stream events and payload snippets. If your model emits reasoning events, you will see entries like `reasoning.start`, `reasoning.delta`, and `reasoning.end`.
 
-### MCP Prerequisite
+### MCP Prerequisite (Optional)
 
 Run `JoshGPT-MCP` and expose it (example at `127.0.0.1:8790`):
 
@@ -131,6 +141,12 @@ Run the direct client-module self-test used by the extension:
 ```bash
 LMSTUDIO_BASE_URL=http://localhost:1234/v1 \
 npm run test:client
+```
+
+Run local shell self-test:
+
+```bash
+npm run test:local-shell
 ```
 
 Run native streaming self-test:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 - If no workspace folder is open, selecting a model still works (writes to user settings scope).
 - Trace pane shows execution events, not hidden model chain-of-thought tokens.
 - In native stream mode, trace includes raw stream event names and payload snippets.
+- Output channel logs tool calls with argument payloads (redacted/truncated for sensitive/large values).
 
 ## Package Test
 
@@ -65,7 +66,7 @@ Install into an isolated extensions directory:
 
 ```bash
 code --extensions-dir /tmp/vscode-lmstudio-ext-test \
-  --install-extension ./joshgpt-0.0.7.vsix --force
+  --install-extension ./joshgpt-0.0.8.vsix --force
 ```
 
 Verify:

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "joshgpt",
   "displayName": "JoshGPT",
-  "description": "Minimal JoshGPT VS Code extension template backed by LM Studio's OpenAI-compatible endpoint.",
-  "version": "0.0.2",
-  "publisher": "context-engineering-template",
+  "description": "Minimal JoshGPT VS Code extension template with OpenAI-compatible and LM Studio native streaming paths.",
+  "version": "0.0.6",
+  "publisher": "josh-phillips-llc",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Josh-Phillips-LLC/Context-Engineering.git"
+    "url": "https://github.com/Josh-Phillips-LLC/JoshGPT-vscode.git"
   },
   "engines": {
     "vscode": "^1.90.0"
@@ -69,15 +69,6 @@
         }
       ]
     },
-    "menus": {
-      "view/title": [
-        {
-          "command": "joshgpt.newSession",
-          "when": "view == joshgpt.sessions",
-          "group": "navigation@1"
-        }
-      ]
-    },
     "configuration": {
       "title": "JoshGPT",
       "properties": {
@@ -85,6 +76,20 @@
           "type": "string",
           "default": "http://localhost:1234/v1",
           "description": "Base URL for the LM Studio OpenAI-compatible endpoint."
+        },
+        "joshgpt.chatEndpointMode": {
+          "type": "string",
+          "default": "openai-compat",
+          "enum": [
+            "openai-compat",
+            "lmstudio-native-stream"
+          ],
+          "description": "Chat transport mode. 'openai-compat' supports MCP tool-calling; 'lmstudio-native-stream' streams native LM Studio events (including reasoning.* when supported)."
+        },
+        "joshgpt.nativeBaseUrl": {
+          "type": "string",
+          "default": "http://localhost:1234",
+          "description": "Base URL for LM Studio native REST endpoint (used with joshgpt.chatEndpointMode=lmstudio-native-stream)."
         },
         "joshgpt.model": {
           "type": "string",
@@ -143,6 +148,7 @@
   "scripts": {
     "test:smoke": "bash ./scripts/smoke-test.sh",
     "test:client": "node ./scripts/client-self-test.js",
+    "test:native": "node ./scripts/native-stream-self-test.js",
     "test:mcp": "node ./scripts/mcp-self-test.js",
     "package:vsix": "npx @vscode/vsce package --no-dependencies"
   },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "joshgpt",
   "displayName": "JoshGPT",
-  "description": "Minimal JoshGPT VS Code extension template with OpenAI-compatible and LM Studio native streaming paths.",
-  "version": "0.0.6",
+  "description": "Minimal JoshGPT VS Code extension template with LM Studio support, local shell tooling, and optional MCP integrations.",
+  "version": "0.0.7",
   "publisher": "josh-phillips-llc",
   "license": "Apache-2.0",
   "repository": {
@@ -141,6 +141,35 @@
           "minimum": 1,
           "maximum": 12,
           "description": "Maximum assistant tool-call rounds per prompt."
+        },
+        "joshgpt.localShell.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable extension-host local shell tool calling (run_local_shell_command)."
+        },
+        "joshgpt.localShell.defaultTimeoutSeconds": {
+          "type": "number",
+          "default": 30,
+          "minimum": 1,
+          "description": "Default timeout for local shell tool calls."
+        },
+        "joshgpt.localShell.maxTimeoutSeconds": {
+          "type": "number",
+          "default": 300,
+          "minimum": 1,
+          "description": "Maximum allowed timeout for local shell tool calls."
+        },
+        "joshgpt.localShell.defaultMaxOutputChars": {
+          "type": "number",
+          "default": 12000,
+          "minimum": 256,
+          "description": "Default output truncation cap per stream for local shell tool calls."
+        },
+        "joshgpt.localShell.maxOutputChars": {
+          "type": "number",
+          "default": 50000,
+          "minimum": 256,
+          "description": "Maximum output truncation cap per stream for local shell tool calls."
         }
       }
     }
@@ -148,6 +177,7 @@
   "scripts": {
     "test:smoke": "bash ./scripts/smoke-test.sh",
     "test:client": "node ./scripts/client-self-test.js",
+    "test:local-shell": "node ./scripts/local-shell-self-test.js",
     "test:native": "node ./scripts/native-stream-self-test.js",
     "test:mcp": "node ./scripts/mcp-self-test.js",
     "package:vsix": "npx @vscode/vsce package --no-dependencies"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "joshgpt",
   "displayName": "JoshGPT",
   "description": "Minimal JoshGPT VS Code extension template with LM Studio support, local shell tooling, and optional MCP integrations.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "josh-phillips-llc",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "joshgpt",
   "displayName": "JoshGPT",
   "description": "Minimal JoshGPT VS Code extension template with LM Studio support, local shell tooling, and optional MCP integrations.",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publisher": "josh-phillips-llc",
   "license": "Apache-2.0",
   "repository": {
@@ -170,6 +170,21 @@
           "default": 50000,
           "minimum": 256,
           "description": "Maximum output truncation cap per stream for local shell tool calls."
+        },
+        "joshgpt.localShell.mirrorTerminalEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Mirror local shell tool execution to a dedicated VS Code terminal in real time."
+        },
+        "joshgpt.localShell.mirrorTerminalName": {
+          "type": "string",
+          "default": "JoshGPT Local Shell",
+          "description": "Name of the terminal used for local shell mirror mode."
+        },
+        "joshgpt.localShell.mirrorTerminalReveal": {
+          "type": "boolean",
+          "default": true,
+          "description": "Reveal the mirrored local shell terminal whenever a local shell tool call starts."
         }
       }
     }

--- a/scripts/local-shell-self-test.js
+++ b/scripts/local-shell-self-test.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+"use strict";
+
+const { runLocalShellToolCall } = require("../src/local-shell-tool");
+
+async function main() {
+  const result = await runLocalShellToolCall(
+    {
+      command: "pwd"
+    },
+    {
+      workspaceRoot: process.cwd(),
+      defaultTimeoutSeconds: 10,
+      maxTimeoutSeconds: 30,
+      defaultMaxOutputChars: 2000,
+      maxOutputCharsCap: 10000
+    }
+  );
+
+  console.log(`[local-shell-test] exit_code=${result.exit_code}`);
+  console.log(`[local-shell-test] cwd=${result.cwd}`);
+  console.log(`[local-shell-test] stdout=${(result.stdout || "").trim()}`);
+
+  if (result.exit_code !== 0) {
+    throw new Error("Local shell command returned non-zero exit code.");
+  }
+  if (!String(result.stdout || "").trim()) {
+    throw new Error("Local shell command returned empty stdout.");
+  }
+
+  console.log("[local-shell-test] PASS");
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`[local-shell-test] FAIL: ${msg}`);
+  process.exit(1);
+});

--- a/scripts/native-stream-self-test.js
+++ b/scripts/native-stream-self-test.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+"use strict";
+
+const {
+  createNativeStreamingChat,
+  listModels
+} = require("../src/lmstudio-client");
+
+async function main() {
+  const baseUrl = process.env.LMSTUDIO_BASE_URL || "http://localhost:1234/v1";
+  const nativeBaseUrl =
+    process.env.LMSTUDIO_NATIVE_BASE_URL || "http://localhost:1234";
+  const apiKey = process.env.LMSTUDIO_API_KEY || "lm-studio";
+  const preferredModel = process.env.LMSTUDIO_MODEL || "";
+
+  console.log(`[native-test] base_url=${baseUrl}`);
+  console.log(`[native-test] native_base_url=${nativeBaseUrl}`);
+
+  const { modelIds } = await listModels({ baseUrl, apiKey });
+  if (!modelIds.length) {
+    throw new Error("LM Studio returned no models.");
+  }
+  const selectedModel = preferredModel || modelIds[0];
+
+  const { events, text } = await createNativeStreamingChat({
+    nativeBaseUrl,
+    baseUrl,
+    apiKey,
+    model: selectedModel,
+    messages: [
+      { role: "system", content: "You are concise." },
+      {
+        role: "user",
+        content:
+          "Reply in exactly three words: native stream working"
+      }
+    ],
+    temperature: 0,
+    maxTokens: 64
+  });
+
+  const reasoningEvents = events.filter((e) =>
+    String(e.event || "").toLowerCase().startsWith("reasoning.")
+  );
+
+  console.log(`[native-test] selected_model=${selectedModel}`);
+  console.log(`[native-test] event_count=${events.length}`);
+  console.log(`[native-test] reasoning_event_count=${reasoningEvents.length}`);
+  console.log(`[native-test] response=${text || "<empty>"}`);
+
+  if (!events.length) {
+    throw new Error("No stream events received from native endpoint.");
+  }
+
+  const hasMessageEvent = events.some((e) =>
+    String(e.event || "").toLowerCase().startsWith("message.")
+  );
+  const hasReasoningEvent = reasoningEvents.length > 0;
+  if (!String(text || "").trim() && !hasMessageEvent && !hasReasoningEvent) {
+    throw new Error(
+      "Native endpoint returned no assistant text and no message/reasoning stream events."
+    );
+  }
+
+  console.log("[native-test] PASS");
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`[native-test] FAIL: ${msg}`);
+  process.exit(1);
+});

--- a/src/chat-runner.js
+++ b/src/chat-runner.js
@@ -1,6 +1,9 @@
 "use strict";
 
-const { createChatCompletion } = require("./lmstudio-client");
+const {
+  createChatCompletion,
+  createNativeStreamingChat
+} = require("./lmstudio-client");
 const { McpHttpClient } = require("./mcp-client");
 
 function stringifyToolResult(result) {
@@ -58,10 +61,104 @@ function countToolCalls(response) {
   return calls.length;
 }
 
+function summarizeEventData(data) {
+  if (data === null || typeof data === "undefined") {
+    return "";
+  }
+  if (typeof data === "string") {
+    return data.slice(0, 600);
+  }
+  try {
+    return JSON.stringify(data, null, 2).slice(0, 1200);
+  } catch {
+    return String(data).slice(0, 600);
+  }
+}
+
+async function runNativeStreamingMode({ config, messages, output, trace, addTrace }) {
+  addTrace("start", "Prompt execution started (mode=lmstudio-native-stream).");
+
+  if (config.mcpEnabled) {
+    addTrace(
+      "mcp",
+      "MCP tool-calling is currently bypassed in lmstudio-native-stream mode."
+    );
+  }
+
+  const streamResult = await createNativeStreamingChat({
+    nativeBaseUrl: config.nativeBaseUrl,
+    baseUrl: config.baseUrl,
+    apiKey: config.apiKey,
+    model: config.model,
+    messages,
+    temperature: config.temperature,
+    maxTokens: config.maxTokens,
+    onEvent: (event) => {
+      const name = String(event.event || "event");
+      const lowered = name.toLowerCase();
+      const delta = typeof event.deltaText === "string" ? event.deltaText : "";
+      const details = delta || summarizeEventData(event.data);
+
+      if (lowered.startsWith("reasoning.")) {
+        addTrace("reasoning", name, details);
+      } else if (lowered === "done" || lowered.endsWith(".done") || lowered.endsWith(".completed")) {
+        addTrace("stream-end", name, details);
+      } else {
+        addTrace("stream", name, details);
+      }
+    }
+  });
+
+  if (output) {
+    output.appendLine(
+      `[joshgpt] native stream completed events=${streamResult.events.length}`
+    );
+  }
+
+  addTrace(
+    "final",
+    "Native streaming response completed.",
+    `events=${streamResult.events.length}`
+  );
+
+  return {
+    text:
+      streamResult.text ||
+      "Model returned no assistant text. Check trace for stream events.",
+    usedTools: false,
+    rounds: 1,
+    trace
+  };
+}
+
 async function runChatWithOptionalMcp({ config, messages, output }) {
+  const trace = [];
+  function addTrace(type, summary, details = "") {
+    trace.push({
+      timestamp: new Date().toISOString(),
+      type: String(type || "event"),
+      summary: String(summary || ""),
+      details: String(details || "")
+    });
+  }
+
+  if (config.chatEndpointMode === "lmstudio-native-stream") {
+    return runNativeStreamingMode({
+      config,
+      messages,
+      output,
+      trace,
+      addTrace
+    });
+  }
+
   let mcpClient = null;
   let openAiTools = [];
   let mcpEnabled = Boolean(config.mcpEnabled);
+  addTrace(
+    "start",
+    `Prompt execution started (mcp=${mcpEnabled ? "enabled" : "disabled"})`
+  );
 
   if (mcpEnabled) {
     try {
@@ -73,13 +170,21 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
       const mcpTools = await mcpClient.listTools();
       openAiTools = asOpenAiTools(mcpTools);
       if (!openAiTools.length) {
+        addTrace("mcp", "MCP connected but no tools were returned.");
         mcpEnabled = false;
+      } else {
+        addTrace(
+          "mcp",
+          `MCP tools loaded (${openAiTools.length}).`,
+          openAiTools.map((tool) => tool.function.name).join(", ")
+        );
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (output) {
         output.appendLine(`[joshgpt] MCP disabled for this turn: ${msg}`);
       }
+      addTrace("mcp", "MCP disabled for this turn.", msg);
       mcpEnabled = false;
     }
   }
@@ -90,6 +195,11 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
     : 4;
 
   for (let round = 0; round < maxRounds; round += 1) {
+    addTrace(
+      "round",
+      `Round ${round + 1}: requesting model completion.`,
+      `message_count=${workingMessages.length}`
+    );
     const response = await createChatCompletion({
       baseUrl: config.baseUrl,
       apiKey: config.apiKey,
@@ -102,11 +212,17 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
     });
 
     const toolCallCount = countToolCalls(response);
+    addTrace(
+      "round",
+      `Round ${round + 1}: model responded (tool_calls=${toolCallCount}).`
+    );
     if (!mcpEnabled || toolCallCount === 0) {
+      addTrace("final", "Model returned final response without additional tool calls.");
       return {
         text: response.text,
         usedTools: false,
-        rounds: round + 1
+        rounds: round + 1,
+        trace
       };
     }
 
@@ -121,19 +237,31 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
     if (output) {
       output.appendLine(`[joshgpt] model requested ${toolCallCount} tool call(s)`);
     }
+    addTrace("tool", `Round ${round + 1}: executing ${toolCallCount} tool call(s).`);
 
     for (const toolCall of response.toolCalls) {
       const toolName = toolCall?.function?.name || "";
       const rawArgs = toolCall?.function?.arguments || "{}";
       const args = parseToolArguments(rawArgs);
+      addTrace(
+        "tool",
+        `Calling tool: ${toolName || "<unknown>"}`,
+        JSON.stringify(args, null, 2)
+      );
 
       let toolResultText;
       try {
         const result = await mcpClient.callTool(toolName, args);
         toolResultText = stringifyToolResult(result);
+        addTrace(
+          "tool",
+          `Tool result: ${toolName || "<unknown>"}`,
+          toolResultText.slice(0, 1200)
+        );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         toolResultText = `MCP tool call failed: ${msg}`;
+        addTrace("tool-error", `Tool failed: ${toolName || "<unknown>"}`, msg);
       }
 
       workingMessages.push({
@@ -145,11 +273,17 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
     }
   }
 
+  addTrace(
+    "limit",
+    "Stopped after reaching max tool-call rounds.",
+    `max_rounds=${maxRounds}`
+  );
   return {
     text:
       "Reached tool-call round limit before final response. Increase joshgpt.mcp.maxToolRounds if needed.",
     usedTools: true,
-    rounds: maxRounds
+    rounds: maxRounds,
+    trace
   };
 }
 

--- a/src/chat-runner.js
+++ b/src/chat-runner.js
@@ -333,7 +333,8 @@ async function runChatWithOptionalMcp({ config, messages, output }) {
             defaultTimeoutSeconds: config.localShellDefaultTimeoutSeconds,
             maxTimeoutSeconds: config.localShellMaxTimeoutSeconds,
             defaultMaxOutputChars: config.localShellDefaultMaxOutputChars,
-            maxOutputCharsCap: config.localShellMaxOutputChars
+            maxOutputCharsCap: config.localShellMaxOutputChars,
+            mirror: config.localShellMirror || null
           });
           toolResultText = JSON.stringify(localResult, null, 2);
           addTrace(

--- a/src/extension.js
+++ b/src/extension.js
@@ -36,7 +36,21 @@ function getConfig() {
       String(rootCfg.get("joshgpt.mcp.baseUrl") || DEFAULT_MCP_BASE_URL)
     ),
     mcpTimeoutMs: Number(rootCfg.get("joshgpt.mcp.timeoutMs") || 15000),
-    mcpMaxToolRounds: Number(rootCfg.get("joshgpt.mcp.maxToolRounds") || 4)
+    mcpMaxToolRounds: Number(rootCfg.get("joshgpt.mcp.maxToolRounds") || 4),
+    localShellEnabled: Boolean(cfg.get("localShell.enabled") ?? true),
+    localShellDefaultTimeoutSeconds: Number(
+      cfg.get("localShell.defaultTimeoutSeconds") || 30
+    ),
+    localShellMaxTimeoutSeconds: Number(cfg.get("localShell.maxTimeoutSeconds") || 300),
+    localShellDefaultMaxOutputChars: Number(
+      cfg.get("localShell.defaultMaxOutputChars") || 12000
+    ),
+    localShellMaxOutputChars: Number(cfg.get("localShell.maxOutputChars") || 50000),
+    workspaceRoot:
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders.length > 0
+        ? vscode.workspace.workspaceFolders[0].uri.fsPath
+        : process.cwd()
   };
 }
 
@@ -112,6 +126,9 @@ async function askModel(output) {
   }
   output.appendLine(
     `[joshgpt] mcp=${cfg.mcpEnabled ? "enabled" : "disabled"} base=${cfg.mcpBaseUrl || "<unset>"}`
+  );
+  output.appendLine(
+    `[joshgpt] local_shell=${cfg.localShellEnabled ? "enabled" : "disabled"}`
   );
 
   const { text } = await runChatWithOptionalMcp({

--- a/src/lmstudio-client.js
+++ b/src/lmstudio-client.js
@@ -2,6 +2,17 @@ function normalizeBaseUrl(baseUrl) {
   return String(baseUrl || "").trim().replace(/\/+$/, "");
 }
 
+function inferNativeBaseUrl(baseUrl) {
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (!normalized) {
+    return "";
+  }
+  if (normalized.endsWith("/v1")) {
+    return normalized.slice(0, -3);
+  }
+  return normalized;
+}
+
 function buildHeaders(apiKey) {
   return {
     "Content-Type": "application/json",
@@ -93,8 +104,270 @@ async function createChatCompletion({
   };
 }
 
+function normalizeSseFrame(rawFrame) {
+  const lines = String(rawFrame || "")
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd());
+
+  let event = "message";
+  const dataLines = [];
+  for (const line of lines) {
+    if (!line || line.startsWith(":")) {
+      continue;
+    }
+    if (line.startsWith("event:")) {
+      event = line.slice("event:".length).trim() || "message";
+      continue;
+    }
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trim());
+    }
+  }
+
+  return {
+    event,
+    dataRaw: dataLines.join("\n").trim()
+  };
+}
+
+function parseMaybeJson(input) {
+  const text = String(input || "").trim();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function buildNativeInput(messages, { systemPrompt, userPrompt } = {}) {
+  if (Array.isArray(messages) && messages.length > 0) {
+    const lines = [];
+    for (const item of messages) {
+      const role = String(item?.role || "user").toUpperCase();
+      const content = String(item?.content || "").trim();
+      if (!content) {
+        continue;
+      }
+      lines.push(`${role}: ${content}`);
+    }
+    if (lines.length > 0) {
+      return [{ type: "text", content: lines.join("\n\n") }];
+    }
+  }
+
+  const fallback = [
+    String(systemPrompt || "").trim(),
+    String(userPrompt || "").trim()
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  return [{ type: "text", content: fallback || "Hello." }];
+}
+
+function extractTextDeltaFromNativeEvent(eventName, payload, rawText) {
+  const evt = String(eventName || "").toLowerCase();
+  const p = payload && typeof payload === "object" ? payload : null;
+
+  if (evt.startsWith("reasoning.")) {
+    return "";
+  }
+
+  if (!p) {
+    return "";
+  }
+
+  const allowDirectCandidates =
+    evt.startsWith("message.") ||
+    evt === "message" ||
+    evt.includes("output_text") ||
+    evt.endsWith(".delta") ||
+    evt === "chat.end";
+
+  const candidates = allowDirectCandidates
+    ? [
+        p.delta,
+        p.text,
+        p.content,
+        p.output_text,
+        p.message,
+        p.response && p.response.output_text,
+        p.data && p.data.delta,
+        p.data && p.data.text,
+        p.data && p.data.content,
+        p.data && p.data.output_text
+      ]
+    : [];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate;
+    }
+  }
+
+  // Common shape for OpenAI-style nested response deltas.
+  const out = p.output && Array.isArray(p.output) ? p.output : [];
+  for (const item of out) {
+    const content = item && Array.isArray(item.content) ? item.content : [];
+    for (const c of content) {
+      if (typeof c?.text === "string" && c.text.length > 0) {
+        return c.text;
+      }
+      if (typeof c?.delta === "string" && c.delta.length > 0) {
+        return c.delta;
+      }
+    }
+  }
+
+  const resultOut =
+    p.result && Array.isArray(p.result.output) ? p.result.output : [];
+  for (const item of resultOut) {
+    if (
+      item &&
+      String(item.type || "").toLowerCase() === "message" &&
+      typeof item.content === "string" &&
+      item.content.length > 0
+    ) {
+      return item.content;
+    }
+  }
+
+  if (evt.endsWith(".delta") && typeof rawText === "string" && rawText.length > 0) {
+    return rawText;
+  }
+  return "";
+}
+
+async function createNativeStreamingChat({
+  nativeBaseUrl,
+  baseUrl,
+  apiKey,
+  model,
+  messages,
+  systemPrompt,
+  userPrompt,
+  temperature,
+  maxTokens,
+  onEvent
+}) {
+  const normalizedNativeBase = normalizeBaseUrl(nativeBaseUrl || inferNativeBaseUrl(baseUrl));
+  if (!normalizedNativeBase) {
+    throw new Error("Native LM Studio base URL is empty.");
+  }
+  const endpoint = `${normalizedNativeBase}/api/v1/chat`;
+
+  const nativeInput = buildNativeInput(messages, { systemPrompt, userPrompt });
+
+  const payload = {
+    model,
+    input: nativeInput,
+    temperature: Number.isFinite(temperature) ? temperature : 0.2,
+    stream: true
+  };
+  if (Number.isFinite(maxTokens)) {
+    payload.max_output_tokens = maxTokens;
+  }
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: buildHeaders(apiKey),
+    body: JSON.stringify(payload)
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Native streaming chat failed (${res.status}): ${body}`);
+  }
+  if (!res.body) {
+    throw new Error("Native streaming response body is unavailable.");
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+
+  let buffer = "";
+  let assistantText = "";
+  let sawMessageDelta = false;
+  const events = [];
+
+  function emitEvent(eventName, dataRaw) {
+    if (!eventName) {
+      return;
+    }
+
+    const maybeJson = parseMaybeJson(dataRaw);
+    const data = maybeJson || dataRaw;
+    let deltaText = extractTextDeltaFromNativeEvent(eventName, maybeJson, dataRaw);
+    const loweredEvent = String(eventName || "").toLowerCase();
+    if (loweredEvent === "message.delta" && deltaText) {
+      sawMessageDelta = true;
+    }
+    if (loweredEvent === "chat.end" && sawMessageDelta) {
+      deltaText = "";
+    }
+    if (deltaText) {
+      assistantText += deltaText;
+    }
+
+    const event = {
+      event: String(eventName),
+      data,
+      dataRaw: String(dataRaw || ""),
+      deltaText: String(deltaText || "")
+    };
+    events.push(event);
+    if (typeof onEvent === "function") {
+      onEvent(event);
+    }
+  }
+
+  function consumeFrame(rawFrame) {
+    const frame = normalizeSseFrame(rawFrame);
+    if (!frame.dataRaw) {
+      return;
+    }
+
+    if (frame.dataRaw === "[DONE]") {
+      emitEvent("done", frame.dataRaw);
+      return;
+    }
+    emitEvent(frame.event, frame.dataRaw);
+  }
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    while (true) {
+      const boundaryIndex = buffer.indexOf("\n\n");
+      if (boundaryIndex < 0) {
+        break;
+      }
+      const rawFrame = buffer.slice(0, boundaryIndex);
+      buffer = buffer.slice(boundaryIndex + 2);
+      consumeFrame(rawFrame);
+    }
+  }
+
+  buffer += decoder.decode();
+  if (buffer.trim()) {
+    consumeFrame(buffer);
+  }
+
+  return {
+    endpoint,
+    events,
+    text: assistantText.trim() || ""
+  };
+}
+
 module.exports = {
   normalizeBaseUrl,
+  inferNativeBaseUrl,
   listModels,
-  createChatCompletion
+  createChatCompletion,
+  createNativeStreamingChat
 };

--- a/src/local-shell-mirror.js
+++ b/src/local-shell-mirror.js
@@ -1,0 +1,112 @@
+"use strict";
+
+const vscode = require("vscode");
+
+function toTerminalText(value) {
+  return String(value || "").replace(/\r?\n/g, "\r\n");
+}
+
+function nowTimeStamp() {
+  return new Date().toISOString().slice(11, 19);
+}
+
+function createLocalShellMirror({ output } = {}) {
+  let terminal = null;
+  let emitter = null;
+  let terminalName = "";
+
+  function ensureTerminal(name) {
+    const requestedName = String(name || "JoshGPT Local Shell").trim() || "JoshGPT Local Shell";
+    if (terminal && emitter && terminalName === requestedName) {
+      return;
+    }
+    if (terminal) {
+      terminal.dispose();
+      terminal = null;
+    }
+    if (emitter) {
+      emitter.dispose();
+      emitter = null;
+    }
+
+    emitter = new vscode.EventEmitter();
+    terminal = vscode.window.createTerminal({
+      name: requestedName,
+      pty: {
+        onDidWrite: emitter.event,
+        open: () => {},
+        close: () => {}
+      }
+    });
+    terminalName = requestedName;
+  }
+
+  function write(text) {
+    if (!emitter) {
+      return;
+    }
+    emitter.fire(toTerminalText(text));
+  }
+
+  function onStart(event) {
+    const command = String(event && event.command ? event.command : "").trim();
+    const cwd = String(event && event.cwd ? event.cwd : "").trim();
+    const shell = String(event && event.shell ? event.shell : "").trim();
+    const timeoutSeconds = Number(event && event.timeout_seconds ? event.timeout_seconds : 0);
+    const reveal = Boolean(event && typeof event.reveal === "boolean" ? event.reveal : true);
+
+    ensureTerminal(event && event.terminal_name);
+    if (terminal && reveal) {
+      terminal.show(true);
+    }
+
+    write(`\r\n[${nowTimeStamp()}] JoshGPT local shell command\r\n`);
+    write(`cwd: ${cwd}\r\n`);
+    write(`shell: ${shell}\r\n`);
+    write(`timeout: ${timeoutSeconds}s\r\n`);
+    write(`$ ${command}\r\n`);
+
+    if (output) {
+      output.appendLine(`[joshgpt] mirrored local shell command in terminal "${terminalName}"`);
+    }
+  }
+
+  function onStdout(event) {
+    write(event && event.text ? event.text : "");
+  }
+
+  function onStderr(event) {
+    write(event && event.text ? event.text : "");
+  }
+
+  function onExit(event) {
+    const exitCode = Number(event && event.exit_code ? event.exit_code : 0);
+    const signal = String(event && event.signal ? event.signal : "");
+    const timedOut = Boolean(event && event.timed_out);
+    const duration = Number(event && event.duration_ms ? event.duration_ms : 0);
+    write(`\r\n[${nowTimeStamp()}] exit_code=${exitCode} signal=${signal || "-"} timed_out=${timedOut} duration_ms=${duration}\r\n`);
+  }
+
+  function dispose() {
+    if (terminal) {
+      terminal.dispose();
+      terminal = null;
+    }
+    if (emitter) {
+      emitter.dispose();
+      emitter = null;
+    }
+  }
+
+  return {
+    onStart,
+    onStdout,
+    onStderr,
+    onExit,
+    dispose
+  };
+}
+
+module.exports = {
+  createLocalShellMirror
+};

--- a/src/local-shell-tool.js
+++ b/src/local-shell-tool.js
@@ -1,0 +1,206 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execFile } = require("child_process");
+
+const LOCAL_SHELL_TOOL_NAME = "run_local_shell_command";
+
+function asInt(value, fallback) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  const parsed = Number.parseInt(String(value || ""), 10);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+  return fallback;
+}
+
+function bounded(value, min, max, fallback) {
+  const parsed = asInt(value, fallback);
+  if (parsed < min) {
+    return min;
+  }
+  if (parsed > max) {
+    return max;
+  }
+  return parsed;
+}
+
+function truncateText(value, maxChars) {
+  const text = String(value || "");
+  if (text.length <= maxChars) {
+    return { text, truncated: false };
+  }
+  const suffix = "\n...[truncated]";
+  const headBudget = Math.max(0, maxChars - suffix.length);
+  return {
+    text: `${text.slice(0, headBudget)}${suffix}`,
+    truncated: true
+  };
+}
+
+function pickShell(command) {
+  if (process.platform === "win32") {
+    return {
+      executable: "powershell.exe",
+      args: ["-NoProfile", "-Command", command]
+    };
+  }
+  if (fs.existsSync("/bin/bash")) {
+    return {
+      executable: "/bin/bash",
+      args: ["-lc", command]
+    };
+  }
+  return {
+    executable: "/bin/sh",
+    args: ["-lc", command]
+  };
+}
+
+function resolveCwd(rawCwd, workspaceRoot) {
+  const fallback = String(workspaceRoot || process.cwd() || ".").trim() || ".";
+  const requested = String(rawCwd || "").trim();
+  const candidate = requested
+    ? (path.isAbsolute(requested) ? requested : path.resolve(fallback, requested))
+    : fallback;
+  const normalized = path.resolve(candidate);
+  if (!fs.existsSync(normalized) || !fs.statSync(normalized).isDirectory()) {
+    throw new Error(`Working directory does not exist or is not a directory: ${normalized}`);
+  }
+  return normalized;
+}
+
+function getLocalShellOpenAiTool() {
+  return {
+    type: "function",
+    function: {
+      name: LOCAL_SHELL_TOOL_NAME,
+      description:
+        "Run a shell command in the current extension host environment. " +
+        "When VS Code is attached to a container, this runs inside that container.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          command: {
+            type: "string",
+            description: "Shell command text to execute."
+          },
+          cwd: {
+            type: "string",
+            description:
+              "Optional working directory. Relative paths resolve from current workspace root."
+          },
+          timeout_seconds: {
+            type: "integer",
+            minimum: 1,
+            maximum: 900,
+            description: "Optional timeout in seconds."
+          },
+          max_output_chars: {
+            type: "integer",
+            minimum: 256,
+            maximum: 200000,
+            description: "Optional max characters kept for stdout and stderr."
+          }
+        },
+        required: ["command"]
+      }
+    }
+  };
+}
+
+async function runLocalShellToolCall(
+  input,
+  {
+    workspaceRoot,
+    defaultTimeoutSeconds = 30,
+    maxTimeoutSeconds = 300,
+    defaultMaxOutputChars = 12000,
+    maxOutputCharsCap = 50000
+  } = {}
+) {
+  const command = String(input && input.command ? input.command : "").trim();
+  if (!command) {
+    throw new Error("run_local_shell_command requires a non-empty 'command'.");
+  }
+
+  const cwd = resolveCwd(input && input.cwd, workspaceRoot);
+  const timeoutSeconds = bounded(
+    input && input.timeout_seconds,
+    1,
+    Math.max(1, asInt(maxTimeoutSeconds, 300)),
+    Math.max(1, asInt(defaultTimeoutSeconds, 30))
+  );
+  const maxOutputChars = bounded(
+    input && input.max_output_chars,
+    256,
+    Math.max(256, asInt(maxOutputCharsCap, 50000)),
+    Math.max(256, asInt(defaultMaxOutputChars, 12000))
+  );
+
+  const shell = pickShell(command);
+  const startedAt = Date.now();
+
+  return new Promise((resolve) => {
+    execFile(
+      shell.executable,
+      shell.args,
+      {
+        cwd,
+        env: process.env,
+        timeout: timeoutSeconds * 1000,
+        maxBuffer: Math.max(maxOutputChars * 6, 1024 * 1024)
+      },
+      (error, stdout, stderr) => {
+        const elapsedMs = Date.now() - startedAt;
+        const stdoutTrunc = truncateText(stdout || "", maxOutputChars);
+        const stderrTrunc = truncateText(stderr || "", maxOutputChars);
+
+        let exitCode = 0;
+        let signal = "";
+        let timedOut = false;
+        if (error) {
+          if (typeof error.code === "number") {
+            exitCode = error.code;
+          } else {
+            exitCode = 1;
+          }
+          signal = String(error.signal || "");
+          timedOut =
+            Boolean(error.killed) ||
+            signal === "SIGTERM" ||
+            signal === "SIGKILL" ||
+            /timed out/i.test(String(error.message || ""));
+        }
+
+        resolve({
+          tool: LOCAL_SHELL_TOOL_NAME,
+          environment: "extension-host",
+          command,
+          cwd,
+          shell: shell.executable,
+          timeout_seconds: timeoutSeconds,
+          max_output_chars: maxOutputChars,
+          duration_ms: elapsedMs,
+          exit_code: exitCode,
+          signal,
+          timed_out: timedOut,
+          stdout: stdoutTrunc.text,
+          stderr: stderrTrunc.text,
+          stdout_truncated: stdoutTrunc.truncated,
+          stderr_truncated: stderrTrunc.truncated
+        });
+      }
+    );
+  });
+}
+
+module.exports = {
+  LOCAL_SHELL_TOOL_NAME,
+  getLocalShellOpenAiTool,
+  runLocalShellToolCall
+};

--- a/src/session-store.js
+++ b/src/session-store.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { randomBytes } = require("crypto");
+
 const STORE_KEY = "joshgpt.sessions.v1";
 const DEFAULT_TITLE = "New Session";
 
@@ -8,7 +10,7 @@ function nowIso() {
 }
 
 function makeId(prefix) {
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `${prefix}-${Date.now()}-${randomBytes(6).toString("hex")}`;
 }
 
 function deriveTitle(text) {


### PR DESCRIPTION
## Summary
- add a native LM Studio streaming chat path (`/api/v1/chat`, `stream: true`) alongside the existing OpenAI-compatible mode
- add endpoint mode settings so JoshGPT can switch between `openai-compat` and `lmstudio-native-stream`
- add and persist a Trace pane in session UI for round/tool/stream events (including `reasoning.*` events when emitted)
- remove duplicate New Session top action by keeping a single in-panel New button
- bump extension to `0.0.6` and update docs for dual-endpoint usage

## Validation
- `npm run test:client`
- `npm run test:mcp`
- `npm run test:native`
- `npm run package:vsix`
