### PR TITLE
Add in-extension settings panel for JoshGPT config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 - Adds a JoshGPT activity-bar view with persistent chat sessions
 - Includes inline, collapsible per-response trace blocks for model/tool execution events
 - Includes a top-of-panel collapsible Settings section for editing `joshgpt.*` configuration
+- Sessions list can be toggled from the chat header and defaults to collapsed to maximize chat width
 - Adds command `JoshGPT: List Models`
 - Adds command `JoshGPT: Ask Model`
 - Adds command `JoshGPT: New Session`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 
 - Adds a JoshGPT activity-bar view with persistent chat sessions
 - Includes a Trace pane for model/tool execution events per session
+- Includes an in-extension Settings panel for editing `joshgpt.*` configuration
 - Adds command `JoshGPT: List Models`
 - Adds command `JoshGPT: Ask Model`
 - Adds command `JoshGPT: New Session`
@@ -55,6 +56,7 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 - In native stream mode, trace includes raw stream event names and payload snippets.
 - Output channel logs tool calls with argument payloads (redacted/truncated for sensitive/large values).
 - Local shell execution is mirrored to a `JoshGPT Local Shell` terminal by default.
+- Settings pane accepts JSON for supported keys, then writes through VS Code config APIs (User or Workspace scope).
 
 ## Package Test
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 ## What It Does
 
 - Adds a JoshGPT activity-bar view with persistent chat sessions
-- Includes a Trace pane for model/tool execution events per session
-- Includes an in-extension Settings panel for editing `joshgpt.*` configuration
+- Includes inline, collapsible per-response trace blocks for model/tool execution events
+- Includes a top-of-panel collapsible Settings section for editing `joshgpt.*` configuration
 - Adds command `JoshGPT: List Models`
 - Adds command `JoshGPT: Ask Model`
 - Adds command `JoshGPT: New Session`
@@ -52,11 +52,12 @@ This starter provides a minimal `JoshGPT` VS Code extension that supports:
 - `Send` in the sidebar sends full in-session message history + `joshgpt.systemPrompt`.
 - `Cmd+Enter` (or `Ctrl+Enter`) sends the current prompt.
 - If no workspace folder is open, selecting a model still works (writes to user settings scope).
-- Trace pane shows execution events, not hidden model chain-of-thought tokens.
+- Inline trace blocks show execution events, not hidden model chain-of-thought tokens.
 - In native stream mode, trace includes raw stream event names and payload snippets.
+- Trace is rendered inline under assistant messages as collapsed `Trace (N events)` blocks.
 - Output channel logs tool calls with argument payloads (redacted/truncated for sensitive/large values).
 - Local shell execution is mirrored to a `JoshGPT Local Shell` terminal by default.
-- Settings pane accepts JSON for supported keys, then writes through VS Code config APIs (User or Workspace scope).
+- Settings panel appears near the top of the chat view and accepts JSON for supported keys, then writes through VS Code config APIs (User or Workspace scope).
 
 ## Package Test
 

--- a/src/session-view-provider.js
+++ b/src/session-view-provider.js
@@ -659,7 +659,6 @@ class JoshGptSessionViewProvider {
     const promptInput = document.getElementById("promptInput");
     const deleteBtn = document.getElementById("deleteSessionBtn");
     const clearTraceBtn = document.getElementById("clearTraceBtn");
-    const settingsPanelEl = document.getElementById("settingsPanel");
     const settingsScopeEl = document.getElementById("settingsScope");
     const settingsJsonEl = document.getElementById("settingsJson");
     const settingsNoteEl = document.getElementById("settingsNote");

--- a/src/session-view-provider.js
+++ b/src/session-view-provider.js
@@ -501,10 +501,7 @@ class JoshGptSessionViewProvider {
     }
     .settings {
       border-bottom: 1px solid var(--vscode-panel-border);
-      display: grid;
-      grid-template-rows: auto auto 1fr auto;
-      min-height: 170px;
-      max-height: 36vh;
+      margin: 0;
     }
     .settings[open] > summary {
       border-bottom: 1px solid var(--vscode-panel-border);
@@ -556,7 +553,9 @@ class JoshGptSessionViewProvider {
     }
     .settings-editor {
       width: 100%;
-      min-height: 120px;
+      height: 140px;
+      min-height: 100px;
+      max-height: 24vh;
       border: none;
       border-bottom: 1px solid var(--vscode-panel-border);
       padding: 8px;


### PR DESCRIPTION
## Summary
- add a first-pass Settings panel directly in the JoshGPT sidebar UI
- allow edit/save/reload of supported `joshgpt.*` settings without leaving the extension
- preserve VS Code settings as source of truth (no separate config store)

## What Changed
- `src/session-view-provider.js`
  - added settings metadata + serialization for supported settings keys
  - added webview message handlers:
    - `saveSettings`
    - `reloadSettings`
    - `openSettingsUi`
  - added save logic with type coercion/validation for string/number/boolean/enum fields
  - added Settings UI section (scope selector, JSON editor, reload/save buttons, open-settings shortcut)
- `README.md`
  - documented in-extension settings panel behavior

## Validation
- `npm run test:local-shell`
- `npm run test:client`
- `LMSTUDIO_BASE_URL=http://localhost:1234/v1 LMSTUDIO_NATIVE_BASE_URL=http://localhost:1234 npm run test:native`
- `JOSHGPT_MCP_BASE_URL=http://127.0.0.1:8791/mcp npm run test:mcp`

Closes #8
